### PR TITLE
使用自定义编译器时,我继承PregCompiler类重写parseCodeBlock方法，需要父类中的变量

### DIFF
--- a/src/Compiler/PregCompiler.php
+++ b/src/Compiler/PregCompiler.php
@@ -27,9 +27,9 @@ use function trim;
 class PregCompiler extends AbstractCompiler
 {
     // add slashes tag name
-    private string $openTagE = '\{\{';
+    protected string $openTagE = '\{\{';
 
-    private string $closeTagE = '\}\}';
+    protected string $closeTagE = '\}\}';
 
     /**
      * like :
@@ -37,9 +37,9 @@ class PregCompiler extends AbstractCompiler
      *
      * @var string
      */
-    private string $blockPattern = '';
+    protected string $blockPattern = '';
 
-    private string $directivePattern = '';
+    protected string $directivePattern = '';
 
     /**
      * @param string $open


### PR DESCRIPTION
PregCompiler类的几个属性 调整成protected